### PR TITLE
Add missing PyYAML to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ mypy-extensions==0.4.1
 nose==1.3.7
 psycopg2==2.7.7
 psycopg2-binary==2.7.7
+PyYAML==5.1.2
 SQLAlchemy==1.3.0b2
 sqlalchemy-stubs==0.1
 SQLAlchemy-Utils==0.33.11


### PR DESCRIPTION
This was probably pulled in via a dependency before, but because we're
explicitly using it, add it to requirements.txt.